### PR TITLE
fix sherpa/sherpa#113 and support numpy 1.10

### DIFF
--- a/sherpatest/ciao4.3/histo/fit.py
+++ b/sherpatest/ciao4.3/histo/fit.py
@@ -2,12 +2,10 @@ from sherpa.astro.ui import *
 import numpy
 load_data(1, 'cstat.dat', colkeys=('zabs1.nh', 'p1.gamma', 'p1.ampl'))
 
-x=None; y=None
-# Can compare numpy version strings this way
-if (numpy.version.version < "1.3.0"):
-    y, x = numpy.histogram(get_data().y, bins=50, normed=True, new=True)
-else:
-    y, x = numpy.histogram(get_data().y, bins=50, normed=True)
+x = None
+y = None
+# The following line won't work with numpy < 1.3.0, but we do not support this version anymore
+y, x = numpy.histogram(get_data().y, bins=50, normed=True)
 x = x[:-1]
 load_arrays(1, x, y)
 set_model(1, gauss1d.g1)


### PR DESCRIPTION
Fix test broken by version string 1.10 (sherpa/sherpa#113). We don't support numpy <1.3.0, so the comparison was obsolete and can be removed.
